### PR TITLE
Started working on methods for checking calling convention

### DIFF
--- a/armprograms/bad_cc2.s
+++ b/armprograms/bad_cc2.s
@@ -1,0 +1,13 @@
+.global _start
+
+.text
+proc1:
+    mov x19, 1
+    ret
+
+_start:
+    bl proc1
+    
+    mov x0, 0
+    mov x8, 93 
+    svc 0

--- a/armprograms/bad_cc3.s
+++ b/armprograms/bad_cc3.s
@@ -1,0 +1,17 @@
+.global _start
+
+.text
+proc1:
+    mov x5, 1
+    ret
+
+_start:
+    sub sp, sp, 8
+    str x5, [sp, 0]
+    bl proc1
+    // ldr x5, [sp, 0]
+    add sp, sp, 8
+    
+    mov x0, 0
+    mov x8, 93 
+    svc 0

--- a/armprograms/good_cc1.s
+++ b/armprograms/good_cc1.s
@@ -1,0 +1,17 @@
+.global _start
+
+.text
+proc1:
+    sub sp, sp, 8
+    str x19, [sp, 0]
+    mov x19, 1
+    ldr x19, [sp, 0]
+    add sp, sp, 8
+    ret
+
+_start:
+    bl proc1
+    
+    mov x0, 0
+    mov x8, 93 
+    svc 0

--- a/bin/cc_validator.ml
+++ b/bin/cc_validator.ml
@@ -21,19 +21,84 @@ The calling convention is as follows:
 The validator checks that the calling convention is followed, including that the stack is properly managed (i.e. stack pointer is properly adjusted).
 *)
 
+(* idea for caller saved regs: 
+once I encounter a sub sp, sp, x , I can enable a flag that allows the pushing of str encounters onto a stack, and then enable another flag once I ret, and as I go pop off the stack
+*)
+
 let ran : bool ref = ref false
 let init_sp : int ref = ref 0
 
-let run_cc_validator (m: Mach.t) : Mach.t =
-  begin
-    let sp = Int64.to_int m.regs.(Mach.reg_index Arm.SP) in
-    if sp = !init_sp then
-      Printf.printf "[cc_validator] stack pointer properly managed\n"
-    else
-      Printf.printf "[cc_validator] stack pointer not properly managed, expected SP: 0x%x, actual SP: 0x%x\n" !init_sp sp;
-    m
-  end
+(* let caller_reg_snapshot : int array ref = ref [||] *)
+let push_caller_regs : bool ref = ref false
+let pop_caller_regs : bool ref = ref false
+let caller_regs_stack : int list ref = ref []
 
+let callee_reg_snapshot : int array ref = ref [||]
+
+let run_cc_validator (m: Mach.t) : Mach.t =
+  let sp = Int64.to_int m.regs.(Mach.reg_index Arm.SP) in
+  if sp = !init_sp then
+    Printf.printf "[cc_validator] stack pointer properly managed\n"
+  else
+    Printf.printf "[cc_validator] stack pointer not properly managed, expected SP: 0x%x, actual SP: 0x%x\n" !init_sp sp;
+  
+  (* check the stack *)
+  if List.length !caller_regs_stack = 0 then
+    Printf.printf "[cc_validator] stack properly managed\n"
+  else
+    Printf.printf "[cc_validator] stack not properly managed, expected stack to be empty, actual: %s\n" (String.concat ", " (List.map string_of_int !caller_regs_stack));
+  m
+
+(* let take_caller_reg_snapshot (m: Mach.t) : Mach.t =
+  (* registers x0-x18 (inclusive)*)
+  caller_reg_snapshot := Array.make 19 0;
+  (* snapshot 0-18 *)
+  for i = 0 to 18 do
+    (!caller_reg_snapshot).(i) <- Int64.to_int m.regs.(i)
+  done;
+  m *)
+
+let take_callee_reg_snapshot (m: Mach.t) : Mach.t =
+  (* registers x19-x28 (inclusive)*)
+  callee_reg_snapshot := Array.make 10 0;
+  (* snapshot 19-28 *)
+  for i = 19 to 28 do
+    (!callee_reg_snapshot).(i - 19) <- Int64.to_int m.regs.(i)
+  done;
+  m
+
+let on_pre_execute (m: Mach.t) : Mach.t =
+  let good = ref true in
+  let pc = m.pc in
+  let instr = Mach.get_insn m pc in
+  (match instr with
+  | (Arm.Bl, _) ->
+    let _ = take_callee_reg_snapshot m in ()
+  | (Arm.Ret, _) ->
+    (* check x19-x28 inclusive, if a register is not the same, print it *)
+    for i = 19 to 28 do
+      if Int64.to_int m.regs.(i) <> (!callee_reg_snapshot).(i - 19) then begin
+        Printf.printf "[cc_validator] register x%d not properly restored, expected: 0x%x, actual: 0x%x\n" i (!callee_reg_snapshot).(i - 19) (Int64.to_int m.regs.(i));
+        good := false
+      end
+    done;
+    if !good then
+      Printf.printf "[cc_validator] callee saved registers properly restored\n"
+  | (Arm.Sub, [Arm.Reg(Arm.SP); Arm.Reg(Arm.SP); _]) -> push_caller_regs := true
+  | (Arm.Add, [Arm.Reg(Arm.SP); Arm.Reg(Arm.SP); _]) -> pop_caller_regs := true
+  | (Arm.Str, [Arm.Reg(src); Arm.Reg(Arm.SP); _]) when !push_caller_regs ->
+    caller_regs_stack := (Int64.to_int m.regs.(Mach.reg_index src)) :: !caller_regs_stack;
+    Printf.printf "[cc_validator] pushing x%d onto stack\n" (Int64.to_int m.regs.(Mach.reg_index src))
+  | (Arm.Ldr, [Arm.Reg(dst); Arm.Reg(Arm.SP); _]) when !pop_caller_regs ->
+    let expected = List.hd !caller_regs_stack in
+    caller_regs_stack := List.tl !caller_regs_stack;
+    if expected <> Int64.to_int m.regs.(Mach.reg_index dst) then
+      Printf.printf "[cc_validator] expected x%d to be 0x%x, actual: 0x%x\n" (Int64.to_int m.regs.(Mach.reg_index dst)) expected (Int64.to_int m.regs.(Mach.reg_index dst))
+    else
+      Printf.printf "[cc_validator] popping x%d off stack\n" (Int64.to_int m.regs.(Mach.reg_index dst))
+  | _ -> ());
+  m
+    
 let on_start (m: Mach.t) : Mach.t =
   init_sp := Int64.to_int m.regs.(Mach.reg_index Arm.SP);
   m
@@ -53,9 +118,7 @@ module M: Plugins.EMULATOR_PLUGIN = struct
     if !ran then run_cc_validator m else m
   
   (* Executes when the machine starts *)
-  let on_start = fun m -> 
-    ignore (on_start m);
-    m
+  let on_start = fun m -> on_start m
 
   (* Executes when the machine stops *)
   let on_exit = fun m ->
@@ -63,8 +126,8 @@ module M: Plugins.EMULATOR_PLUGIN = struct
     m
 
   (* Executes before instruction is run *)
-  let on_pre_execute = fun m -> m
-
+  let on_pre_execute = fun m -> on_pre_execute m
+    
   (* Executes after PC increases *)
   let on_post_execute = fun m -> m
 end

--- a/bin/dune
+++ b/bin/dune
@@ -21,4 +21,4 @@
  (name cc_validator)
  (modules cc_validator)
  (modes plugin)
- (libraries arm mach emulator plugins))
+ (libraries arm mach plugins))


### PR DESCRIPTION
Works for callee saved registers, method:
On BL, take snapshot pre execution
On RET, pre execution, compares current register values against snapshop

Caller saved registers method (not working currently):
After encountering a sub sp, sp, x,
Push any STR onto a the stack
When encountering LDR, pop corresponding STR off of the stack

Current issues:
Well, just doesn't work.

Other changes:
created more arm files for testing calling convention (different aspects of cc)
removed a library from the dune file for cc (not using emulator, so removed)